### PR TITLE
from collections.abc import MutableMapping for Python >= v3.10

### DIFF
--- a/buildconfig/buildconfig.py
+++ b/buildconfig/buildconfig.py
@@ -11,14 +11,16 @@ import json
 import hashlib
 import fnmatch
 import re
-import collections
 import pipes
 import shlex
 import yaml
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 
-
-class SchemaDict(collections.MutableMapping):
+class SchemaDict(MutableMapping):
     def __init__(self, *args, **kwargs):
         self.store = {}
         self.update(dict(*args, **kwargs))


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.9.html#you-should-check-for-deprecationwarning-in-your-code
> Aliases to [Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) in the [collections](https://docs.python.org/3/library/collections.html#module-collections) module, like collections.Mapping alias to [collections.abc.Mapping](https://docs.python.org/3/library/collections.abc.html#collections.abc.Mapping), are kept for one last release for backward compatibility. They will be removed from Python 3.10.
```
  File ".../python3.12/site-packages/buildconfig/buildconfig.py", line 21, in <module>
    class SchemaDict(collections.MutableMapping):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'collections' has no attribute 'MutableMapping'
```